### PR TITLE
chore: update otel version for Linux installation

### DIFF
--- a/linux/install.sh
+++ b/linux/install.sh
@@ -22,7 +22,7 @@ fi
 # Detect OS and architecture
 OS=$(uname | tr '[:upper:]' '[:lower:]')
 ARCH=$(uname -m)
-OTEL_VERSION="0.111.0"
+OTEL_VERSION="0.143.0"
 
 if [ "$ARCH" = "x86_64" ]; then
     ARCH="amd64"


### PR DESCRIPTION
The current version of Otel is [0.143.0](https://github.com/open-telemetry/opentelemetry-collector-contrib/releases/tag/v0.143.0).

I downloaded Otel using your link, but some parameters from other external receivers were not working, such as the `metrics` option in `httpcheck` and the `events` option in `postgresql`.

I discovered that this happens because the version provided is outdated.